### PR TITLE
Enforce 90% test coverage threshold

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -64,6 +64,12 @@ export default defineConfig({
         '**/mockData',
         '**/__mocks__',
       ],
+      thresholds: {
+        statements: 90,
+        branches: 90,
+        functions: 90,
+        lines: 90,
+      },
     },
     // Use threads pool which is more stable than forks
     pool: 'threads',


### PR DESCRIPTION
## Summary
- Add 90% coverage thresholds for statements, branches, functions, and lines in vitest configuration
- Tests may currently fail this threshold but enforcement is now in place for future development
- This will help maintain code quality standards going forward

## Test plan
- [x] Verify vitest configuration includes coverage thresholds
- [x] Confirm tests can be run with coverage reporting
- [ ] Future: Improve test coverage to meet the 90% threshold

🤖 Generated with [Claude Code](https://claude.ai/code)